### PR TITLE
fix: complete libva driver contract to fix vaInitialize error 20 (hardware-verified)

### DIFF
--- a/approach1-compute-encoder/src/va_backend.c
+++ b/approach1-compute-encoder/src/va_backend.c
@@ -684,6 +684,81 @@ VAStatus bc250_PutImage(VADriverContextP ctx, VASurfaceID surface, VAImageID ima
     return VA_STATUS_SUCCESS;
 }
 
+VAStatus bc250_SetImagePalette(VADriverContextP ctx, VAImageID image, unsigned char *palette) {
+    (void)ctx; (void)image; (void)palette;
+    return VA_STATUS_ERROR_UNIMPLEMENTED;
+}
+
+/* Subpictures are not supported by this driver. Query returns zero available
+ * formats (the standard way to report "unsupported"); the rest are stubs to
+ * satisfy libva's vtable completeness check. */
+VAStatus bc250_QuerySubpictureFormats(VADriverContextP ctx, VAImageFormat *format_list, unsigned int *flags, unsigned int *num_formats) {
+    (void)ctx; (void)format_list; (void)flags;
+    if (!num_formats) return VA_STATUS_ERROR_INVALID_PARAMETER;
+    *num_formats = 0;
+    return VA_STATUS_SUCCESS;
+}
+
+VAStatus bc250_CreateSubpicture(VADriverContextP ctx, VAImageID image, VASubpictureID *subpicture) {
+    (void)ctx; (void)image; (void)subpicture;
+    return VA_STATUS_ERROR_UNIMPLEMENTED;
+}
+
+VAStatus bc250_DestroySubpicture(VADriverContextP ctx, VASubpictureID subpicture) {
+    (void)ctx; (void)subpicture;
+    return VA_STATUS_ERROR_UNIMPLEMENTED;
+}
+
+VAStatus bc250_SetSubpictureImage(VADriverContextP ctx, VASubpictureID subpicture, VAImageID image) {
+    (void)ctx; (void)subpicture; (void)image;
+    return VA_STATUS_ERROR_UNIMPLEMENTED;
+}
+
+VAStatus bc250_SetSubpictureChromakey(VADriverContextP ctx, VASubpictureID subpicture, unsigned int chromakey_min, unsigned int chromakey_max, unsigned int chromakey_mask) {
+    (void)ctx; (void)subpicture; (void)chromakey_min; (void)chromakey_max; (void)chromakey_mask;
+    return VA_STATUS_ERROR_UNIMPLEMENTED;
+}
+
+VAStatus bc250_SetSubpictureGlobalAlpha(VADriverContextP ctx, VASubpictureID subpicture, float global_alpha) {
+    (void)ctx; (void)subpicture; (void)global_alpha;
+    return VA_STATUS_ERROR_UNIMPLEMENTED;
+}
+
+VAStatus bc250_AssociateSubpicture(VADriverContextP ctx, VASubpictureID subpicture, VASurfaceID *target_surfaces, int num_surfaces,
+                                   short src_x, short src_y, unsigned short src_width, unsigned short src_height,
+                                   short dest_x, short dest_y, unsigned short dest_width, unsigned short dest_height,
+                                   unsigned int flags) {
+    (void)ctx; (void)subpicture; (void)target_surfaces; (void)num_surfaces;
+    (void)src_x; (void)src_y; (void)src_width; (void)src_height;
+    (void)dest_x; (void)dest_y; (void)dest_width; (void)dest_height; (void)flags;
+    return VA_STATUS_ERROR_UNIMPLEMENTED;
+}
+
+VAStatus bc250_DeassociateSubpicture(VADriverContextP ctx, VASubpictureID subpicture, VASurfaceID *target_surfaces, int num_surfaces) {
+    (void)ctx; (void)subpicture; (void)target_surfaces; (void)num_surfaces;
+    return VA_STATUS_ERROR_UNIMPLEMENTED;
+}
+
+/* Display attributes are not supported. Query/Get report zero/no-op success
+ * (the standard way to report "unsupported"); Set is unimplemented since
+ * nothing was ever exposed to set. */
+VAStatus bc250_QueryDisplayAttributes(VADriverContextP ctx, VADisplayAttribute *attr_list, int *num_attributes) {
+    (void)ctx; (void)attr_list;
+    if (!num_attributes) return VA_STATUS_ERROR_INVALID_PARAMETER;
+    *num_attributes = 0;
+    return VA_STATUS_SUCCESS;
+}
+
+VAStatus bc250_GetDisplayAttributes(VADriverContextP ctx, VADisplayAttribute *attr_list, int num_attributes) {
+    (void)ctx; (void)attr_list; (void)num_attributes;
+    return VA_STATUS_SUCCESS;
+}
+
+VAStatus bc250_SetDisplayAttributes(VADriverContextP ctx, VADisplayAttribute *attr_list, int num_attributes) {
+    (void)ctx; (void)attr_list; (void)num_attributes;
+    return VA_STATUS_ERROR_UNIMPLEMENTED;
+}
+
 VAStatus bc250_QueryVideoProcFilters(VADriverContextP ctx, VAContextID context, VAProcFilterType *filters, unsigned int *num_filters) {
     (void)ctx; (void)context;
     if (!num_filters) return VA_STATUS_ERROR_INVALID_PARAMETER;
@@ -736,6 +811,19 @@ VAStatus bc250_Initialize(VADriverContextP ctx, int *major_version, int *minor_v
     ctx->pDriverData = data;
     ctx->str_vendor = "AMD BC-250 RDNA2 Compute VA-API Driver";
 
+    /* libva's core vaInitialize() validates these counts and the vtable
+     * completeness before returning control to the driver's caller - both
+     * are mandatory, not just documentation. */
+    ctx->max_profiles = MAX_PROFILES;
+    ctx->max_entrypoints = MAX_ENTRYPOINTS;
+    ctx->max_attributes = MAX_CONFIG_ATTRIBUTES;
+    ctx->max_image_formats = MAX_IMAGE_FORMATS;
+    /* libva requires these positive even though we report zero actual
+     * subpicture formats / display attributes at query time - they only
+     * size libva's internal arrays, they aren't a "supported" flag. */
+    ctx->max_subpic_formats = 1;
+    ctx->max_display_attributes = 1;
+
     /* Wire complete vtable */
     ctx->vtable->vaTerminate = bc250_Terminate;
     ctx->vtable->vaQueryConfigProfiles = bc250_QueryConfigProfiles;
@@ -766,6 +854,18 @@ VAStatus bc250_Initialize(VADriverContextP ctx, int *major_version, int *minor_v
     ctx->vtable->vaDeriveImage = bc250_DeriveImage;
     ctx->vtable->vaGetImage = bc250_GetImage;
     ctx->vtable->vaPutImage = bc250_PutImage;
+    ctx->vtable->vaSetImagePalette = bc250_SetImagePalette;
+    ctx->vtable->vaQuerySubpictureFormats = bc250_QuerySubpictureFormats;
+    ctx->vtable->vaCreateSubpicture = bc250_CreateSubpicture;
+    ctx->vtable->vaDestroySubpicture = bc250_DestroySubpicture;
+    ctx->vtable->vaSetSubpictureImage = bc250_SetSubpictureImage;
+    ctx->vtable->vaSetSubpictureChromakey = bc250_SetSubpictureChromakey;
+    ctx->vtable->vaSetSubpictureGlobalAlpha = bc250_SetSubpictureGlobalAlpha;
+    ctx->vtable->vaAssociateSubpicture = bc250_AssociateSubpicture;
+    ctx->vtable->vaDeassociateSubpicture = bc250_DeassociateSubpicture;
+    ctx->vtable->vaQueryDisplayAttributes = bc250_QueryDisplayAttributes;
+    ctx->vtable->vaGetDisplayAttributes = bc250_GetDisplayAttributes;
+    ctx->vtable->vaSetDisplayAttributes = bc250_SetDisplayAttributes;
 
     if (major_version) *major_version = VA_MAJOR_VERSION;
     if (minor_version) *minor_version = VA_MINOR_VERSION;

--- a/approach1-compute-encoder/src/va_backend.h
+++ b/approach1-compute-encoder/src/va_backend.h
@@ -20,6 +20,8 @@
 
 #define MAX_PROFILES 16
 #define MAX_ENTRYPOINTS 16
+#define MAX_CONFIG_ATTRIBUTES 16
+#define MAX_IMAGE_FORMATS 8
 #define MAX_CONFIGS 256
 #define MAX_SURFACES 1024
 #define MAX_CONTEXTS 64
@@ -161,6 +163,22 @@ VAStatus bc250_DestroyImage(VADriverContextP ctx, VAImageID image);
 VAStatus bc250_DeriveImage(VADriverContextP ctx, VASurfaceID surface, VAImage *image);
 VAStatus bc250_GetImage(VADriverContextP ctx, VASurfaceID surface, int x, int y, unsigned int width, unsigned int height, VAImageID image);
 VAStatus bc250_PutImage(VADriverContextP ctx, VASurfaceID surface, VAImageID image, int src_x, int src_y, unsigned int src_width, unsigned int src_height, int dest_x, int dest_y, unsigned int dest_width, unsigned int dest_height);
+VAStatus bc250_SetImagePalette(VADriverContextP ctx, VAImageID image, unsigned char *palette);
+
+/* Subpictures (unsupported - stubs required by the libva driver contract) */
+VAStatus bc250_QuerySubpictureFormats(VADriverContextP ctx, VAImageFormat *format_list, unsigned int *flags, unsigned int *num_formats);
+VAStatus bc250_CreateSubpicture(VADriverContextP ctx, VAImageID image, VASubpictureID *subpicture);
+VAStatus bc250_DestroySubpicture(VADriverContextP ctx, VASubpictureID subpicture);
+VAStatus bc250_SetSubpictureImage(VADriverContextP ctx, VASubpictureID subpicture, VAImageID image);
+VAStatus bc250_SetSubpictureChromakey(VADriverContextP ctx, VASubpictureID subpicture, unsigned int chromakey_min, unsigned int chromakey_max, unsigned int chromakey_mask);
+VAStatus bc250_SetSubpictureGlobalAlpha(VADriverContextP ctx, VASubpictureID subpicture, float global_alpha);
+VAStatus bc250_AssociateSubpicture(VADriverContextP ctx, VASubpictureID subpicture, VASurfaceID *target_surfaces, int num_surfaces, short src_x, short src_y, unsigned short src_width, unsigned short src_height, short dest_x, short dest_y, unsigned short dest_width, unsigned short dest_height, unsigned int flags);
+VAStatus bc250_DeassociateSubpicture(VADriverContextP ctx, VASubpictureID subpicture, VASurfaceID *target_surfaces, int num_surfaces);
+
+/* Display attributes (unsupported - stubs required by the libva driver contract) */
+VAStatus bc250_QueryDisplayAttributes(VADriverContextP ctx, VADisplayAttribute *attr_list, int *num_attributes);
+VAStatus bc250_GetDisplayAttributes(VADriverContextP ctx, VADisplayAttribute *attr_list, int num_attributes);
+VAStatus bc250_SetDisplayAttributes(VADriverContextP ctx, VADisplayAttribute *attr_list, int num_attributes);
 
 /* Video Processing (VPP) */
 VAStatus bc250_QueryVideoProcFilters(VADriverContextP ctx, VAContextID context, VAProcFilterType *filters, unsigned int *num_filters);


### PR DESCRIPTION
## Summary

Fixes Issue #2 (`vaInitialize failed with error code 20`) by completing the libva driver contract in `bc250_Initialize()`. Verified on **physical BC-250 hardware**.

## Root cause

The Vulkan/GPU compute backend was never actually the problem here — on real hardware it initializes correctly and finds the APU via RADV (`AMD BC-250 (RADV GFX1013)`). The failure was two libva driver-contract violations in `va_backend.c`:

1. **`ctx->max_profiles` / `max_entrypoints` / `max_attributes` / `max_image_formats` / `max_subpic_formats` / `max_display_attributes` were never set.** libva's core `vaInitialize()` validates these counts and aborts if they're zero — even though `MAX_PROFILES`/`MAX_ENTRYPOINTS` were already defined in `va_backend.h`, they were just never assigned to the context.
2. **The vtable was missing 12 required entries** — `vaSetImagePalette` and the full subpicture/display-attribute family (`vaQuerySubpictureFormats`, `vaCreateSubpicture`, `vaDestroySubpicture`, `vaSetSubpictureImage`, `vaSetSubpictureChromakey`, `vaSetSubpictureGlobalAlpha`, `vaAssociateSubpicture`, `vaDeassociateSubpicture`, `vaQueryDisplayAttributes`, `vaGetDisplayAttributes`, `vaSetDisplayAttributes`). libva requires every one of these to be non-NULL even when a driver supports none of that functionality — they just need to report zero formats/attributes or return `VA_STATUS_ERROR_UNIMPLEMENTED`.

Note `max_subpic_formats`/`max_display_attributes` specifically must be a **positive** placeholder (libva keeps failing init if they're `0`) even though the corresponding Query functions correctly report zero actual formats/attributes at runtime — these two are just internal array-size hints, not a "supported" flag.

## Hardware validation (BC-250, RADV GFX1013, Bazzite/Fedora 43)

```
$ LIBVA_DRIVER_NAME=bc250 vainfo --display drm --device /dev/dri/renderD128
...
[bc250-gpu] Found AMD BC-250 APU (0x13FE) - AMD BC-250 (RADV GFX1013)
[bc250-gpu] Using general compute queue family 0
vainfo: VA-API version: 1.23 (libva 2.23.0)
vainfo: Driver version: AMD BC-250 RDNA2 Compute VA-API Driver
vainfo: Supported profile and entrypoints
      VAProfileH264ConstrainedBaseline:	VAEntrypointEncSlice
      VAProfileH264Main               :	VAEntrypointEncSlice
      VAProfileH264High               :	VAEntrypointEncSlice
```

```
$ ffmpeg -y -vaapi_device /dev/dri/renderD128 -f lavfi -i testsrc=duration=5:size=1280x720:rate=30 \
    -vf 'format=nv12,hwupload' -c:v h264_vaapi test.mp4
```
produces a valid `.mp4` that `ffprobe` parses cleanly — correct SPS/PPS in `extradata`, correct 150-frame/5s duration, `is_avc=true`.

Other notes from bring-up, for anyone else testing on real hardware:
- The board only exposed a general graphics+compute queue family, not a dedicated async-compute-only queue — confirms the documented fallback path is what actually runs on this GPU.
- `active_cu_number` reported by the kernel was 24, not the theoretical 40.

## Known remaining gap (not fixed here, filed for follow-up)

The resulting bitstream is currently **header/skip-only with zero residual data**. Decoding the output triggers full-frame error concealment and a flat gray image — this matches the gap already called out in the README. Root cause: `h264_encoder_encode_frame()` hardcodes `cbp_chroma=0, cbp_luma=0` in the `cavlc_write_mb_i16x16_header()` call, and never calls the already-implemented, spec-compliant `cavlc_write_4x4_block()` / `cavlc_write_chroma_dc_block()` (they exist in `cavlc.c`/`cavlc.h` but are dead code). Wiring real quantized coefficients from the GPU's `quant_levels_buffer`/entropy readback into those existing functions is a separately-scoped fix — happy to follow up with a PR for that too if useful.

## Testing

- Built from source on the board itself (Bazzite/Fedora 43, ostree/immutable — cmake/libva-devel/libdrm-devel headers obtained without touching the base image).
- `vainfo` confirms driver load + entrypoints as above.
- `ffmpeg` + `ffprobe` round-trip produces a structurally valid H.264 file.
